### PR TITLE
Use matrix and upload on release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,8 +4,6 @@ on:
   push:
   pull_request:
   workflow_dispatch:
-  release:
-    types: ['published', 'released']
   schedule:
     # build at least once a month
     - cron: '0 0 1 * *'
@@ -37,13 +35,6 @@ jobs:
         with:
           name: AppImage ${{ matrix.ARCH }}
           path: linuxdeploy-plugin-appimage*.AppImage*
-      - name: Upload release asset
-        if: github.event_name == 'release' && startsWith(github.ref, 'refs/tags/v')
-        uses: shogo82148/actions-upload-release-asset@v1
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: linuxdeploy-plugin-appimage*.AppImage*
-          asset_name: AppImage ${{ matrix.ARCH }}
 
   upload:
     name: Create release and upload artifacts

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,38 +4,30 @@ on:
   push:
   pull_request:
   workflow_dispatch:
+  release:
+    types: ['published', 'released']
   schedule:
     # build at least once a month
     - cron: '0 0 1 * *'
 
 jobs:
-  appimage-x86_64:
-    name: AppImage x86_64
+  appimage:
+    strategy:
+      matrix:
+        include:
+          - arch: 'x86_64'
+          - arch: 'i386'
+          
+    name: AppImage ${{ matrix.arch }}
     runs-on: ubuntu-18.04
     env:
-      ARCH: x86_64
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: recursive
-      - name: Build AppImage
-        run: bash -ex ci/build-appimage.sh
-      - name: Archive artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: AppImage x86_64
-          path: linuxdeploy-plugin-appimage*.AppImage*
-
-  appimage-i386:
-    name: AppImage i386
-    runs-on: ubuntu-18.04
-    env:
-      ARCH: i386
+      ARCH: ${{ matrix.arch }}
     steps:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
       - name: Install dependencies
+        if: ${{ matrix.arch == 'i386' }}
         run: |
             sudo dpkg --add-architecture i386
             sudo apt-get update
@@ -45,14 +37,20 @@ jobs:
       - name: Archive artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: AppImage i386
+          name: AppImage ${{ matrix.arch }}
           path: linuxdeploy-plugin-appimage*.AppImage*
+      - name: Upload release asset
+        if: github.event_name == 'release' && startsWith(github.ref, 'refs/tags/v')
+        uses: shogo82148/actions-upload-release-asset@v1
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: linuxdeploy-plugin-appimage*.AppImage*
+          asset_name: AppImage ${{ matrix.arch }}
 
   upload:
     name: Create release and upload artifacts
     needs:
-      - appimage-x86_64
-      - appimage-i386
+      - appimage
     runs-on: ubuntu-latest
     steps:
       - name: Download artifacts

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,13 +21,13 @@ jobs:
     name: AppImage ${{ matrix.arch }}
     runs-on: ubuntu-18.04
     env:
-      ARCH: ${{ matrix.arch }}
+      ARCH: ${{ matrix.ARCH }}
     steps:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
       - name: Install dependencies
-        if: ${{ matrix.arch == 'i386' }}
+        if: ${{ matrix.ARCH == 'i386' }}
         run: |
             sudo dpkg --add-architecture i386
             sudo apt-get update
@@ -37,7 +37,7 @@ jobs:
       - name: Archive artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: AppImage ${{ matrix.arch }}
+          name: AppImage ${{ matrix.ARCH }}
           path: linuxdeploy-plugin-appimage*.AppImage*
       - name: Upload release asset
         if: github.event_name == 'release' && startsWith(github.ref, 'refs/tags/v')
@@ -45,7 +45,7 @@ jobs:
         with:
           upload_url: ${{ github.event.release.upload_url }}
           asset_path: linuxdeploy-plugin-appimage*.AppImage*
-          asset_name: AppImage ${{ matrix.arch }}
+          asset_name: AppImage ${{ matrix.ARCH }}
 
   upload:
     name: Create release and upload artifacts

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,9 +14,7 @@ jobs:
   appimage:
     strategy:
       matrix:
-        include:
-          - arch: 'x86_64'
-          - arch: 'i386'
+        arch: ['x86_64', 'i386']
           
     name: AppImage ${{ matrix.arch }}
     runs-on: ubuntu-18.04


### PR DESCRIPTION
References https://github.com/linuxdeploy/linuxdeploy-plugin-appimage/issues/21

This will upload an AppImage if a new release is created (from the release tab on github), with a `v` prefix (e.g. `v1.0.0`).

I am aware, this conflicts with the current approach which seems to be creating a tag locally and creating a release from that. But since the tag is currently a moving target and the aim of this is a manually triggered release, this might be justified.

Whereas for nightly builds, it might be interesting to https://nightly.link/ instead and avoid the moving tag as currently done.

This also deduplicates code by using a build matrix.

I am completely open to change the approach if you prefer otherwise. My main interest is getting a stable link to an immutable release.