### PR TITLE
Check if -static-{libgcc,libstdc++} flags are supported before passing them

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,6 +14,13 @@ endif()
 
 set(_target_name linuxdeploy-plugin-appimage)
 
+# Clang does not support -static-libstdc++ and -static-libgcc, but just -static
+# is enough to link everything statically. We check for these flags and only
+# use them if they're supported.
+include(CheckCXXCompilerFlag)
+check_cxx_compiler_flag(-static-libstdc++ STATIC_LIBSTDCXX_SUPPORTED)
+check_cxx_compiler_flag(-static-libgcc STATIC_LIBGCC_SUPPORTED)
+
 # main executable
 add_executable(${_target_name} main.cpp)
 
@@ -21,10 +28,14 @@ target_link_libraries(${_target_name} args)
 
 set(_cflags
     -static
-    -static-libstdc++
-    -static-libgcc
     -flto
 )
+if(STATIC_LIBSTDCXX_SUPPORTED)
+    list(APPEND _cflags -static-libstdc++)
+endif()
+if(STATIC_LIBGCC_SUPPORTED)
+    list(APPEND _cflags -static-libgcc)
+endif()
 target_compile_options(${_target_name} PUBLIC ${_cflags})
 target_link_options(${_target_name} PUBLIC ${_cflags})
 


### PR DESCRIPTION
This fixes build on FreeBSD (with Clang).